### PR TITLE
Add locale support for the CarbonPeriod in Laravel

### DIFF
--- a/src/Carbon/Laravel/ServiceProvider.php
+++ b/src/Carbon/Laravel/ServiceProvider.php
@@ -4,6 +4,7 @@ namespace Carbon\Laravel;
 
 use Carbon\Carbon;
 use Carbon\CarbonImmutable;
+use Carbon\CarbonPeriod;
 use Illuminate\Contracts\Events\Dispatcher as DispatcherContract;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Events\EventDispatcher;
@@ -37,6 +38,7 @@ class ServiceProvider extends \Illuminate\Support\ServiceProvider
         $locale = $app->getLocale();
         Carbon::setLocale($locale);
         CarbonImmutable::setLocale($locale);
+        CarbonPeriod::setLocale($locale);
 
         // @codeCoverageIgnoreStart
         if (class_exists(IlluminateCarbon::class)) {

--- a/tests/Laravel/ServiceProviderTest.php
+++ b/tests/Laravel/ServiceProviderTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 namespace Tests\Laravel;
 
 use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use Carbon\CarbonPeriod;
 use Carbon\Laravel\ServiceProvider;
 use Illuminate\Events\Dispatcher;
 use Illuminate\Events\EventDispatcher;
@@ -34,22 +36,37 @@ class ServiceProviderTest extends TestCase
     {
         // Reset language
         Carbon::setLocale('en');
+        CarbonImmutable::setLocale('en');
+        CarbonPeriod::setLocale('en');
 
         include_once __DIR__.'/ServiceProvider.php';
         $service = new ServiceProvider($dispatcher);
 
         $this->assertSame('en', Carbon::getLocale());
+        $this->assertSame('en', CarbonImmutable::getLocale());
+        $this->assertSame('en', CarbonPeriod::getLocale());
+
         $service->boot();
         $this->assertSame('en', Carbon::getLocale());
+        $this->assertSame('en', CarbonImmutable::getLocale());
+        $this->assertSame('en', CarbonPeriod::getLocale());
+
         $service->app->register();
         $service->boot();
         $this->assertSame('de', Carbon::getLocale());
+        $this->assertSame('de', CarbonImmutable::getLocale());
+        $this->assertSame('de', CarbonPeriod::getLocale());
+
         $service->app->setLocale('fr');
         $this->assertSame('fr', Carbon::getLocale());
+        $this->assertSame('fr', CarbonImmutable::getLocale());
+        $this->assertSame('fr', CarbonPeriod::getLocale());
         $this->assertNull($service->register());
 
         // Reset language
         Carbon::setLocale('en');
+        CarbonImmutable::setLocale('en');
+        CarbonPeriod::setLocale('en');
 
         $service->app->removeService('events');
         $this->assertNull($service->boot());


### PR DESCRIPTION
### Fix

After upgrading to carbon 2.23.1, the language locale set in the Laravel config was not being set for CarbonPeriod, returning the default value

```
        dump(\Carbon\Carbon::getLocale()); // 'ja'
        dump(\Carbon\CarbonImmutable::getLocale()); // 'ja
        dump(\Carbon\CarbonPeriod::getLocale()); // 'en'
```

### changes
- add CarbonPeriod to the updateLocale in the laravel serviceprovider
- add CarbonPeriod and CarbonImmutable to localization tests